### PR TITLE
Custom: [ADD] property, property offer: Add Computed Fields and Onchanges functions following Odoo Guide t#70762

### DIFF
--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
-from odoo import fields, models
+from odoo import api,fields, models
 
 class EstateProperty(models.Model):
     _name = "property"
@@ -51,5 +51,30 @@ class EstateProperty(models.Model):
     tag_ids = fields.Many2many("property.tag")
     partner_id = fields.Many2one("res.partner")
     offer_ids = fields.One2many("property.offer", "property_id")
+    total_area = fields.Float(compute="_compute_total_area", string="Total Area (sqm)")
+    best_offer = fields.Float(compute="_compute_best_price", string="Best Offer")
 
+
+    @api.depends("living_area", "garden_area")
+    def _compute_total_area(self):
+        for record in self:
+            record.total_area = record.living_area + record.garden_area
+
+    @api.depends("offer_ids.price")
+    def _compute_best_price(self):
+        for record in self:
+            if record.offer_ids:
+                offer_prices = record.offer_ids.mapped("price")
+                record.best_offer = max(offer_prices)
+            else:
+                record.best_offer = 0
+
+    @api.onchange('garden')
+    def _onchange_garden(self):
+        if self.garden:
+            self.garden_area = 10
+            self.garden_orientation = 'north'
+        else:
+            self.garden_area = 0
+            self.garden_orientation = False
 

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -13,7 +13,7 @@ class EstateProperty(models.Model):
     expected_price = fields.Float(required=True)
     selling_price = fields.Float(readonly=True, copy=False)
     bedrooms = fields.Integer(default=2)
-    living_area = fields.Integer(string = 'Living Area (sqm)')
+    living_area = fields.Integer()
     facades = fields.Integer()
     garage = fields.Boolean()
     garden = fields.Boolean()
@@ -52,7 +52,7 @@ class EstateProperty(models.Model):
     partner_id = fields.Many2one("res.partner")
     offer_ids = fields.One2many("property.offer", "property_id")
     total_area = fields.Float(compute="_compute_total_area", string="Total Area (sqm)")
-    best_offer = fields.Float(compute="_compute_best_price", string="Best Offer")
+    best_offer = fields.Float(compute="_compute_best_price")
 
 
     @api.depends("living_area", "garden_area")

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,4 +1,4 @@
-from datetime import timedelta,datetime
+from datetime import timedelta
 from odoo import api,fields, models
 
 
@@ -16,7 +16,7 @@ class PropertyOffer(models.Model):
     )
     partner_id = fields.Many2one("res.partner", required=True)
     property_id = fields.Many2one("property", required=True)
-    validity = fields.Integer(compute="_compute_validity", inverse="_inverse_validity")
+    validity = fields.Integer(compute="_compute_validity", inverse="_inverse_validity", default = 7)
     date_deadline = fields.Datetime()
 
     @api.depends("date_deadline")

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -17,7 +17,7 @@ class PropertyOffer(models.Model):
     partner_id = fields.Many2one("res.partner", required=True)
     property_id = fields.Many2one("property", required=True)
     validity = fields.Integer(compute="_compute_validity", inverse="_inverse_validity")
-    date_deadline = fields.Datetime(date_only=True)
+    date_deadline = fields.Datetime()
 
     @api.depends("date_deadline")
     def _compute_validity(self):

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,4 +1,5 @@
-from odoo import fields, models
+from datetime import timedelta,datetime
+from odoo import api,fields, models
 
 
 class PropertyOffer(models.Model):
@@ -15,3 +16,15 @@ class PropertyOffer(models.Model):
     )
     partner_id = fields.Many2one("res.partner", required=True)
     property_id = fields.Many2one("property", required=True)
+    validity = fields.Integer(compute="_compute_validity", inverse="_inverse_validity")
+    date_deadline = fields.Datetime(date_only=True)
+
+    @api.depends("date_deadline")
+    def _compute_validity(self):
+        for record in self:
+            record.validity = abs((record.date_deadline - fields.Datetime.now()).days) if record.date_deadline else 7
+
+    def _inverse_validity(self):
+        for record in self:
+            record.date_deadline = fields.Datetime.now() + timedelta(days=(record.validity))
+

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -2,9 +2,7 @@ from odoo import fields, models
 
 class PropertyType(models.Model):
     _name = "property.type"
-    _description = """
-    This is a model that represents the different types of properties
-    """
+    _description = "This is a model that represents the different types of properties"
 
     name = fields.Char(required=True)
     property_ids = fields.One2many("property", "property_type_id")

--- a/estate/views/estate_property_offer_views.xml
+++ b/estate/views/estate_property_offer_views.xml
@@ -8,6 +8,8 @@
             <tree string="Property Offers">
                 <field name="price" />
                 <field name="partner_id"/>
+                <field name="validity"/>
+                <field name="date_deadline"/>
                 <field name="status"/>
             </tree>
         </field>

--- a/estate/views/estate_property_tag_views.xml
+++ b/estate/views/estate_property_tag_views.xml
@@ -14,7 +14,7 @@
         <form string="Property Tag">
             <sheet>
                 <group>
-                    <field name="name"/>
+                    <field name="name" string="Name" />
                 </group>
             </sheet>
         </form>

--- a/estate/views/estate_property_tag_views.xml
+++ b/estate/views/estate_property_tag_views.xml
@@ -14,7 +14,7 @@
         <form string="Property Tag">
             <sheet>
                 <group>
-                    <field name="name" string="Name" />
+                    <field name="name"/>
                 </group>
             </sheet>
         </form>

--- a/estate/views/estate_property_type_views.xml
+++ b/estate/views/estate_property_type_views.xml
@@ -13,11 +13,16 @@
       <field name="arch" type="xml">
         <form string="Property Type">
           <sheet>
-            <group>
+            <div class="oe_title">
                 <h1>
-                    <field name="name"/>
+                    <field name="name" />
                 </h1>
-            </group>
+            </div>
+
+            <h1>
+                <field name="name"  />
+            </h1>
+
           </sheet>
         </form>
       </field>

--- a/estate/views/estate_property_type_views.xml
+++ b/estate/views/estate_property_type_views.xml
@@ -18,11 +18,6 @@
                     <field name="name" />
                 </h1>
             </div>
-
-            <h1>
-                <field name="name"  />
-            </h1>
-
           </sheet>
         </form>
       </field>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -46,6 +46,7 @@
                         </group>
                         <group>
                             <field name="expected_price" />
+                            <field name="best_offer" />
                             <field name="selling_price" />
                         </group>
                         <notebook>
@@ -53,12 +54,13 @@
                                 <group>
                                     <field name="description"/>
                                     <field name="bedrooms" />
-                                    <field name="living_area"/>
+                                    <field name="living_area" string="Living Area (sqm)" />
                                     <field name="facades" />
                                     <field name="garage" />
                                     <field name="garden" />
-                                    <field name="garden_area" string="Garden Area (sqm)"/>
+                                    <field name="garden_area" />
                                     <field name="garden_orientation" />
+                                    <field name="total_area" />
                                 </group>
                             </page>
                             <page string="Offers">
@@ -92,18 +94,17 @@
           <field name="postcode" />
           <field name="expected_price" />
           <field name="bedrooms" />
-          <field name="living_area" filter_domain="[('living_area', '>=', self)]" />
+          <field name="living_area"  filter_domain="[('living_area', '>=', self)]" />
           <field name="facades" />
             <separator />
-          <filter
-                        string="Available"
-                        name="active"
-                        domain="[('active', '=', True), '|', ('state', '=', 'new'), ('state', '=', 'offer recived')]"
-                    />
-
-          <group expand="1" string="Group By">
-            <filter string="Postcode" name="postcode" context="{'group_by':'postcode'}" />
-          </group>
+            <filter
+                string="Available"
+                name="active"
+                domain="[('active', '=', True), '|', ('state', '=', 'new'), ('state', '=', 'offer recived')]"
+                />
+            <group expand="1" string="Group By">
+                <filter string="Postcode" name="postcode" context="{'group_by':'postcode'}" />
+            </group>
         </search>
       </field>
     </record>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -94,7 +94,7 @@
           <field name="postcode" />
           <field name="expected_price" />
           <field name="bedrooms" />
-          <field name="living_area"  filter_domain="[('living_area', '>=', self)]" />
+          <field name="living_area" filter_domain="[('living_area', '>=', self)]" />
           <field name="facades" />
             <separator />
             <filter


### PR DESCRIPTION
**Explanation**

Added Computed Fields and Onchanges functions following Odoo Guide on chapter 09:

**In the property model**, the total area is computed depending the living area and the garden area : 

![Captura de Pantalla 2023-04-24 a la(s) 21 22 41](https://user-images.githubusercontent.com/108036643/234167267-44c20231-0a07-4aeb-beb1-52d39a599341.png)

The best offer field is computed comparing all the offers made for the property:
![Captura de Pantalla 2023-04-24 a la(s) 21 26 33](https://user-images.githubusercontent.com/108036643/234167660-c5c51c1a-cd07-40da-b916-2ad7c43b1cc9.png)

When enabling the garden it will set a default area of 10 and an orientation to North.
![Captura de Pantalla 2023-04-24 a la(s) 21 32 57](https://user-images.githubusercontent.com/108036643/234168242-be251341-b905-4505-8b83-db5bed6c4c12.png)


In the property offer model, the validity date should be computed and can be updated:

![Captura de Pantalla 2023-04-24 a la(s) 21 29 24](https://user-images.githubusercontent.com/108036643/234167965-8359b98a-5f90-4fa5-a46e-f781676a1141.png)

