### PR TITLE
[IMP] estate:  added python and sql constraints to models following Odoo Guide t#70762

### DIFF
--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
-from odoo import api,fields, models, exceptions
+from odoo import api,fields, models, tools, exceptions
 
 class EstateProperty(models.Model):
     _name = "property"
@@ -120,7 +120,6 @@ class EstateProperty(models.Model):
             self.garden_area = 0
             self.garden_orientation = False
 
-
     def action_sold(self):
         for record in self:
             if record.state == "canceled":
@@ -128,9 +127,6 @@ class EstateProperty(models.Model):
             elif record.state == "sold":
                 raise exceptions.UserError("Property is already sold")
             record.state = "sold"
-
-
-
 
     def action_cancel(self):
         for record in self:
@@ -140,4 +136,16 @@ class EstateProperty(models.Model):
                 raise exceptions.UserError("Property is already canceled")
             record.state = "canceled"
 
+    _sql_constraints = [
+        (
+            "check_expected_price",
+            "CHECK(expected_price > 0)",
+            "Expected price must be strictly positive",
+        ),
+        (
+            "check_selling_price",
+            "CHECK(selling_price > 0)",
+            "Selling price must be strictly positive",
+        )
+    ]
 

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -44,6 +44,8 @@ class PropertyOffer(models.Model):
         accepted_offer = self.property_id.offer_ids.filtered(lambda o : o.status == 'accepted')
         if accepted_offer:
             raise exceptions.UserError("More than one offer cannot be accepted")
+        if self.property_id.expected_price and self.price < self.property_id.expected_price * 0.9:
+            raise exceptions.UserError("The selling price must be at least 90% of the expected price! You must reduce the expected price if you want to accept this offer'")
         self.status = "accepted"
         self.property_id.selling_price = self.price
         self.property_id.buyer_id = self.buyer_id
@@ -51,3 +53,11 @@ class PropertyOffer(models.Model):
     def action_deny(self):
         for record in self:
             record.status = "refused"
+
+    _sql_constraints = [
+        (
+            "check_price",
+            "CHECK(price > 0)",
+            "Offer price must be strictly positive",
+        )
+    ]

--- a/estate/models/estate_property_tag.py
+++ b/estate/models/estate_property_tag.py
@@ -6,3 +6,7 @@ class PropertyTag(models.Model):
     _description = "This is a model that represents tags that can be associated with different properties."
 
     name = fields.Char(required=True)
+
+    _sql_constraints = [
+        ('unique_name', 'unique(name)', 'The name must be unique'),
+    ]

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -6,3 +6,7 @@ class PropertyType(models.Model):
 
     name = fields.Char(required=True)
     property_ids = fields.One2many("property", "property_type_id")
+
+    _sql_constraints = [
+        ('unique_name', 'unique(name)', 'The name must be unique'),
+    ]


### PR DESCRIPTION
**Explanations**

A property expected price must be strictly positive
 
<img width="783" alt="Captura de Pantalla 2023-04-27 a la(s) 13 17 27" src="https://user-images.githubusercontent.com/108036643/234977157-7e2898fd-9eea-48c4-8231-53ae974d8de5.png">


An offer price must be strictly positive
<img width="604" alt="Captura de Pantalla 2023-04-27 a la(s) 13 37 42" src="https://user-images.githubusercontent.com/108036643/234977422-df5f7cb6-6073-4e4d-b1bd-2f475cfd85ce.png">


A property tag name and property type name must be unique
<img width="744" alt="Captura de Pantalla 2023-04-27 a la(s) 13 38 32" src="https://user-images.githubusercontent.com/108036643/234977478-78cea395-4705-4f09-ae58-05f6f9afd1aa.png">

The selling price cannot be lower than 90% of the expected price.
![Captura de Pantalla 2023-04-27 a la(s) 12 59 59](https://user-images.githubusercontent.com/108036643/234977742-7d73ecfc-7970-43b9-ac84-e7845f868fed.png)



