### PR TITLE
[IMP] estate: improved views of models following Odoo Guide t#70762

### DIFF
--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -5,6 +5,7 @@ from odoo import api,fields, models, tools, exceptions
 class EstateProperty(models.Model):
     _name = "property"
     _description = "This model provides a representation of a real estate"
+    _order= "id desc"
 
     name = fields.Char(required=True)
     description = fields.Text()
@@ -53,6 +54,7 @@ class EstateProperty(models.Model):
     offer_ids = fields.One2many("property.offer", "property_id")
     total_area = fields.Float(compute="_compute_total_area", string="Total Area (sqm)")
     best_offer = fields.Float(compute="_compute_best_price")
+    sequence = fields.Integer(default=1)
 
 
     @api.depends("living_area", "garden_area")
@@ -148,4 +150,3 @@ class EstateProperty(models.Model):
             "Selling price must be strictly positive",
         )
     ]
-

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -1,10 +1,10 @@
 from datetime import timedelta
-from odoo import api,fields, models, exceptions
-
+from odoo import api,fields, models, exceptions, tools
 
 class PropertyOffer(models.Model):
     _name = "property.offer"
     _description = "This model represents an offer made by a buyer for a property. "
+    _order = "price desc"
 
     price = fields.Float()
     status = fields.Selection(
@@ -19,6 +19,7 @@ class PropertyOffer(models.Model):
     property_id = fields.Many2one("property", required=True)
     validity = fields.Integer(compute="_compute_validity", inverse="_inverse_validity", default = 7)
     date_deadline = fields.Date(compute="_compute_date_deadline", inverse="_inverse_date_deadline")
+    property_type_id = fields.Many2one("property.type", related="property_id.property_type_id", readonly=True, store=True)
 
     @api.depends("validity")
     def _compute_date_deadline(self):

--- a/estate/models/estate_property_tag.py
+++ b/estate/models/estate_property_tag.py
@@ -4,8 +4,10 @@ from odoo import fields, models
 class PropertyTag(models.Model):
     _name = "property.tag"
     _description = "This is a model that represents tags that can be associated with different properties."
+    _order = "name"
 
     name = fields.Char(required=True)
+    color = fields.Integer()
 
     _sql_constraints = [
         ('unique_name', 'unique(name)', 'The name must be unique'),

--- a/estate/models/estate_property_type.py
+++ b/estate/models/estate_property_type.py
@@ -1,12 +1,36 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 class PropertyType(models.Model):
     _name = "property.type"
     _description = "This is a model that represents the different types of properties"
+    _order = "name"
 
     name = fields.Char(required=True)
     property_ids = fields.One2many("property", "property_type_id")
+    offer_ids = fields.One2many("property.offer", "property_type_id")
+    offer_count = fields.Integer(compute="_compute_offer_count")
 
     _sql_constraints = [
         ('unique_name', 'unique(name)', 'The name must be unique'),
     ]
+
+    @api.depends('offer_ids')
+    def _compute_offer_count(self):
+        for record in self:
+            record.offer_count = len(record.offer_ids)
+
+    def get_offers(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": "Offers",
+            "view_mode": "tree",
+            "res_model": "property.offer",
+            "domain": [("property_type_id", "=", self.id)],
+            "context": "{'create': False}",
+        }
+
+
+
+
+

--- a/estate/views/estate_property_type_views.xml
+++ b/estate/views/estate_property_type_views.xml
@@ -13,11 +13,28 @@
       <field name="arch" type="xml">
         <form string="Property Type">
           <sheet>
+            <div name="button_box" position="inside">
+              <button class="oe_stat_button" type="object" name="get_offers" icon="fa-money">
+                <field string="Offers" name="offer_count" widget="statinfo" />
+              </button>
+            </div>
             <div class="oe_title">
                 <h1>
                     <field name="name" />
                 </h1>
             </div>
+              <notebook>
+                <page string="Properties">
+                  <field name="property_ids" widget="one2many_list" >
+                    <tree >
+                        <field name="sequence" widget="handle"/>
+                        <field name="name" />
+                        <field name="expected_price" />
+                        <field name="state" />
+                    </tree>
+                  </field>
+                </page>
+              </notebook>
           </sheet>
         </form>
       </field>

--- a/estate/views/estate_property_views.xml
+++ b/estate/views/estate_property_views.xml
@@ -2,9 +2,11 @@
 
 <odoo>
     <record id="property_action" model="ir.actions.act_window">
-      <field name="name">Properties</field>
-      <field name="res_model">property</field>
-      <field name="view_mode">tree,form,kanban</field>
+        <field name="name">Properties</field>
+        <field name="res_model">property</field>
+        <field name="view_mode">tree,form,kanban</field>
+        <field name="search_view_id" ref="estate_property_search_view"/>
+        <field name="context">{'search_default_available': 1}</field>
     </record>
 
     <record id="estate_property_view_tree" model="ir.ui.view">
@@ -12,16 +14,21 @@
         <field name="model">property</field>
         <field name="arch" type="xml">
             <tree string="Properties"
+                decoration-success="state=='offer_received' or state=='offer_accepted'"
+                decoration-bf="state=='offer_accepted'"
+                decoration-muted="state=='sold'"
                 >
                 <field name="name" string="Title"/>
+                <field name="property_type_id"/>
                 <field name="postcode"/>
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                 <field name="bedrooms"/>
                 <field name="living_area"/>
                 <field name="expected_price"/>
                 <field name="selling_price"/>
                 <field name="date_availability" string="Available From"/>
                 <field name="state" invisible="1" />
-            </tree>
+            </tree >
         </field>
     </record>
 
@@ -31,25 +38,27 @@
         <field name="arch" type="xml">
             <form string="Property">
                 <header>
-                    <button name="action_sold" type="object" string="Sold"/>
-                    <button name="action_cancel" type="object" string="Cancel"/>
+                    <button name="action_sold" type="object" string="Sold" class="oe_left"
+                        states="new,offer_received,offer_accepted"/>
+                    <button name="action_cancel" type="object" string="Cancel" class="oe_left"
+                        states="new,offer_received,offer_accepted"/>
+                    <field name="state" widget="statusbar" class="oe_right"/>
                 </header>
-
                 <sheet>
                     <div class="oe_title">
                         <h1>
                             <field name="name" placeholder="Title"/>
                         </h1>
                         <label for="tag_ids">Tags:</label>
-                        <field name="tag_ids" widget="many2many_tags" editable="true" placeholder="Tags"/>
+                        <field name="tag_ids" widget="many2many_tags" editable="true" placeholder="Tags" options="{'color_field': 'color'}"/>
                         <field name="active" invisible="1" />
                     </div>
                     <group>
                         <group>
                             <field name="state" />
-                            <field name="property_type_id" />
+                            <field name="property_type_id" options="{'no_create': True, 'no_edit': True}"/>
                             <field name="postcode" />
-                            <field name="date_availability" string="Available From" />
+                            <field name="date_availability" string="Available From" optional="1" invisible="1"/>
                         </group>
                         <group>
                             <field name="expected_price" />
@@ -65,14 +74,18 @@
                                     <field name="facades" />
                                     <field name="garage" />
                                     <field name="garden" />
-                                    <field name="garden_area" />
-                                    <field name="garden_orientation" />
+                                    <field name="garden_area" attrs="{'invisible': [('garden', '=', False)]}" />
+                                    <field name="garden_orientation" attrs="{'invisible': [('garden', '=', False)]}" />
                                     <field name="total_area" />
                                 </group>
                             </page>
                             <page string="Offers">
-                                <field name="offer_ids" widget="one2many_list">
-                                    <tree>
+                                <field name="offer_ids" widget="one2many_list"
+                                    attrs="{'readonly': [('state', 'in', ['offer_accepted', 'sold', 'canceled'])]}">
+                                    <tree editable="true"
+                                        decoration-success="status=='accepted'"
+                                        decoration-danger="status=='refused'"
+                                        >
                                         <field name="price" />
                                         <field name="partner_id" />
                                         <field name="validity" />
@@ -82,7 +95,7 @@
                                             name="action_confirm"
                                             type="object"
                                             icon="fa-check"
-                                             title="Accept Offer"
+                                            title="Accept Offer"
                                             attrs="{'invisible': [('status', 'in', ['accepted','refused'])]}"
                                             />
                                         <button
@@ -109,28 +122,19 @@
         </field>
     </record>
 
-    <record id="estate_property_search_view" model="ir.ui.view">
-      <field name="name">property.search</field>
-      <field name="model">property</field>
-      <field name="arch" type="xml">
-        <search string="Estate">
-          <field name="name" string="Title" />
-          <field name="postcode" />
-          <field name="expected_price" />
-          <field name="bedrooms" />
-          <field name="living_area" filter_domain="[('living_area', '>=', self)]" />
-          <field name="facades" />
-            <separator />
-            <filter
-                string="Available"
-                name="active"
-                domain="[('active', '=', True), '|', ('state', '=', 'new'), ('state', '=', 'offer recived')]"
-                />
-            <group expand="1" string="Group By">
-                <filter string="Postcode" name="postcode" context="{'group_by':'postcode'}" />
-            </group>
-        </search>
-      </field>
+   <record id="estate_property_search_view" model="ir.ui.view">
+        <field name="name">property.search</field>
+        <field name="model">property</field>
+        <field name="arch" type="xml">
+            <search>
+                <filter string="Available" name="available" domain="[('state', '=', 'available')]"/>
+                <filter string="Sold" name="sold" domain="[('state', '=', 'sold')]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Tags" name="tags" context="{'group_by': 'tag_ids'}"/>
+                    <filter string="Property Type" name="property_type" context="{'group_by': 'property_type_id'}"/>
+                </group>
+            </search>
+        </field>
     </record>
 
 


### PR DESCRIPTION
**Explanations**

The property view should display a widget that exhibits the four states: New, Offer Received, Offer Accepted, and Sold. The tags should be visible with colors, and the Sold and Cancel buttons should be conditionally displayed. If the property is already sold or canceled, the buttons should not appear.

![Captura de Pantalla 2023-05-01 a la(s) 15 39 52](https://user-images.githubusercontent.com/108036643/235536614-f5cd8e42-b1c4-4d4c-8881-286652b2a65a.png)


![Captura de Pantalla 2023-05-01 a la(s) 15 40 08](https://user-images.githubusercontent.com/108036643/235536626-a2b31777-1029-48f8-824e-5ea1d88add9e.png)


The property and offer list views should have color decorations ( properties with an offer received are green, properties with an offer accepted are green and bold and properties sold are muted). Additionally, offers and tags will be editable directly in the list, and the availability date will be hidden by default

![Captura de Pantalla 2023-05-01 a la(s) 15 43 07](https://user-images.githubusercontent.com/108036643/235536830-55fc6d64-8f2c-4f30-9a7a-3fde24f4e85d.png)
![Captura de Pantalla 2023-05-01 a la(s) 15 44 03](https://user-images.githubusercontent.com/108036643/235536934-e01b0aca-ece7-40d6-84e0-17f463cc4dd0.png)

The available properties will be filtered by default
![Captura de Pantalla 2023-05-01 a la(s) 15 46 14](https://user-images.githubusercontent.com/108036643/235537247-597425c0-d98f-4a3e-86e3-802bf1d96e03.png)

There is a new  stat button on the property type form view which shows the list of all offers related to properties of the given type when it is clicked on.


![Captura de Pantalla 2023-05-01 a la(s) 15 47 53](https://user-images.githubusercontent.com/108036643/235537494-85282e07-235c-4143-8607-972f8eef9c3c.png)


![Captura de Pantalla 2023-05-01 a la(s) 15 47 45](https://user-images.githubusercontent.com/108036643/235537519-7985e974-1501-49db-8bee-fb5a2bf106f2.png)

