### PR TITLE
[IMP] estate: prevent  property deleting and add a field to the base.view_users_form to models following Odoo Guide t#70762

### DIFF
--- a/estate/__manifest__.py
+++ b/estate/__manifest__.py
@@ -13,6 +13,7 @@
         "views/estate_property_tag_views.xml",
         "views/estate_property_offer_views.xml",
         "views/estate_menus.xml",
+        "views/users_views.xml",
     ],
     "application": True,
 }

--- a/estate/models/__init__.py
+++ b/estate/models/__init__.py
@@ -2,3 +2,4 @@ from . import estate_property
 from . import estate_property_type
 from . import estate_property_tag
 from . import estate_property_offer
+from . import users

--- a/estate/models/estate_property.py
+++ b/estate/models/estate_property.py
@@ -150,3 +150,9 @@ class EstateProperty(models.Model):
             "Selling price must be strictly positive",
         )
     ]
+
+    @api.ondelete(at_uninstall=False)
+    def unlink_if_new_or_cancelled(self):
+        for record in self:
+            if record.state not in ['new', 'canceled']:
+                raise exceptions.UserError("Property can only be deleted if it's in 'New' or 'Canceled' state.")

--- a/estate/models/estate_property_offer.py
+++ b/estate/models/estate_property_offer.py
@@ -62,3 +62,13 @@ class PropertyOffer(models.Model):
             "Offer price must be strictly positive",
         )
     ]
+
+    @api.model
+    def create(self, vals):
+        property_obj = self.env['property'].browse(vals['property_id'])
+        offers = property_obj.offer_ids
+        max_offer = max(offers.mapped("price"), default=0)
+        if vals["price"] < max_offer:
+            raise exceptions.UserError("Cannot create an offer with a lower amount than an existing offer.")
+        property_obj.state = 'offer_received'
+        return super().create(vals)

--- a/estate/models/users.py
+++ b/estate/models/users.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class Users(models.Model):
+    _inherit = "res.users"
+
+    property_ids = fields.One2many("property", "salesperson_id", string="Properties")

--- a/estate/security/ir.model.access.csv
+++ b/estate/security/ir.model.access.csv
@@ -1,5 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_estate_property,access.property,model_property,base.group_user,1,1,1,0
+access_estate_property,access.property,model_property,base.group_user,1,1,1,1
 access_property_type,access_property_type,model_property_type,base.group_user,1,1,1,1
 access_property_tag,access_property_tag,model_property_tag,base.group_user,1,1,1,1
 access_property_offer,access_property_offer,model_property_offer,base.group_user,1,1,1,1

--- a/estate/views/users_views.xml
+++ b/estate/views/users_views.xml
@@ -1,0 +1,23 @@
+<odoo>
+    <data>
+        <record id="res_users_view_form" model="ir.ui.view">
+            <field name="name">res.users.view.form.inherit.properties</field>
+            <field name="model">res.users</field>
+            <field name="inherit_id" ref="base.view_users_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//page[@name='preferences']" position="after">
+                    <page name="properties" string="Real Estate Properties">
+                        <field name="property_ids" widget="one2many_list">
+                            <tree editable="false">
+                                <field name="name" />
+                                <field name="expected_price" />
+                                <field name="state" />
+                            </tree>
+                        </field>
+                    </page>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>
+


### PR DESCRIPTION
**Explanations**

It should not be possible to delete a property which is not new or canceled.
![Captura de Pantalla 2023-05-01 a la(s) 17 31 15](https://user-images.githubusercontent.com/108036643/235549619-092c56e7-c986-4fd7-9ce2-61b2ed48388c.png)

When an offer is created, the property state should change to ‘Offer Received’ and It should not be possible to create an offer with a lower price than an existing offer
![Captura de Pantalla 2023-05-01 a la(s) 16 30 45](https://user-images.githubusercontent.com/108036643/235549743-f52c359d-2aaa-4f73-b0b1-525a22fafbe6.png)
![Captura de Pantalla 2023-05-01 a la(s) 16 31 34](https://user-images.githubusercontent.com/108036643/235549808-605ab24d-c722-459c-996e-3e557983233a.png)


The list of available properties linked to a salesperson should be displayed in their user form view
<img width="1034" alt="Captura de Pantalla 2023-05-01 a la(s) 17 02 57" src="https://user-images.githubusercontent.com/108036643/235549941-2cbe3979-cbd7-4d8e-825c-e6e31b0ac434.png">
